### PR TITLE
chore(deps): slow dependabot to monthly + 30-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
+    cooldown:
+      default-days: 30
+    groups:
+      actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
Slow non-security dependabot updates:

- `interval: weekly` → `monthly`
- add `cooldown.default-days: 30` (PRs only for versions that have survived a month)
- group all updates into a single PR per ecosystem

Security updates are unaffected — they ride a separate track and fire on alerts regardless of schedule.