### PR TITLE
fix(core): handle update-ca-certificates failure on restricted K8s runners

### DIFF
--- a/scripts/dock-bootstrap.sh
+++ b/scripts/dock-bootstrap.sh
@@ -92,8 +92,23 @@ fi
 # 4. Update the system trust store
 # -------------------------------------------------------------------------
 if [ "$COUNT" -gt 0 ]; then
-  update-ca-certificates 2>/dev/null
-  echo "dock-bootstrap: imported $COUNT certificate source(s) into trust store"
+  if update-ca-certificates 2>/dev/null; then
+    echo "dock-bootstrap: imported $COUNT certificate source(s) into trust store"
+  else
+    # Fallback for restricted environments (e.g. K8s runners where
+    # /etc/ssl/certs is not writable for temp-file creation).
+    # Manually append new certs to the CA bundle.
+    bundle="${SSL_CERT_FILE:-/etc/ssl/certs/ca-certificates.crt}"
+    if [ -w "$bundle" ]; then
+      for f in "$DEST"/*.crt; do
+        [ -f "$f" ] && cat "$f" >> "$bundle"
+      done
+      echo "dock-bootstrap: imported $COUNT certificate source(s) into trust store (fallback)"
+    else
+      echo "dock-bootstrap: warning: cannot update trust store — read-only filesystem" >&2
+      echo "dock-bootstrap: imported $COUNT cert(s) to $DEST but bundle is unchanged" >&2
+    fi
+  fi
 else
   echo "dock-bootstrap: no certificates found, trust store unchanged"
 fi


### PR DESCRIPTION
## Summary

- Add fallback path in dock-bootstrap when update-ca-certificates fails due to restricted /etc/ssl/certs/ permissions (common on K8s runners with non-root security contexts)
- On failure, manually appends cert files to the CA bundle
- If the bundle itself is read-only, emits a clear warning

## Context

Discovered during corporate GitLab validation on gitlabee.dt.renault.com. The K8s runner security context prevents creating temp files in /etc/ssl/certs/, causing update-ca-certificates to fail with:

```
Failed to open temporary file /etc/ssl/certs/bundleXXXXXX for ca bundle
```

The cert extraction and import steps all succeed -- only the final trust store rebuild fails. The fallback concatenates certs directly into the existing bundle file, which only requires write permission on the file (not directory-level create permission).