### PR TITLE
fix(core): preserve cluster-injected CAs in fallback CA bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
 - **core:** ensure newline separators between PEM certs in fallback CA bundle
   ([#38]) ([12275ec])
 
-[0.1.5]: https://github.com/driftsys/dock/compare/v0.1.4...v0.1.5
-[12275ec]: https://github.com/driftsys/dock/commit/12275ec
-[#38]: https://github.com/driftsys/dock/issues/38
+## [Unreleased]
+
+### Bug Fixes
+
+- **core:** preserve cluster-injected CA certs in fallback bundle —
+  fixes TLS failures for proxy-intercepted domains (e.g. deno.land)
 
 ## [0.1.4] (2026-04-23)
 

--- a/scripts/dock-bootstrap.sh
+++ b/scripts/dock-bootstrap.sh
@@ -113,16 +113,25 @@ fi
 
 # Fallback — /etc/ssl/certs/ is read-only (common on K8s runners where
 # the directory is mounted from a ConfigMap).  Build a private CA bundle
-# from the package source certs so we get the full Mozilla root store
-# regardless of what the ConfigMap contains.
+# and redirect all TLS env vars to it.
 DOCK_BUNDLE="/etc/dock/ca-bundle.crt"
 DOCK_ENV="/etc/dock/ca.env"
+SYS_BUNDLE="${SSL_CERT_FILE:-/etc/ssl/certs/ca-certificates.crt}"
 
-# Build from source: Mozilla root CAs + any imported certs.
+# Start from the existing system bundle when available — it may contain
+# extra CAs injected by the cluster (e.g. corporate proxy CAs in a
+# ConfigMap).  Fall back to the Mozilla source certs shipped by the
+# ca-certificates package only when the system bundle is missing.
 : > "$DOCK_BUNDLE"
-for f in /usr/share/ca-certificates/mozilla/*.crt; do
-  [ -f "$f" ] && { cat "$f"; echo; } >> "$DOCK_BUNDLE"
-done
+if [ -r "$SYS_BUNDLE" ]; then
+  { cat "$SYS_BUNDLE"; echo; } >> "$DOCK_BUNDLE"
+else
+  for f in /usr/share/ca-certificates/mozilla/*.crt; do
+    [ -f "$f" ] && { cat "$f"; echo; } >> "$DOCK_BUNDLE"
+  done
+fi
+
+# Append any imported certs (env vars, drop dir, CI_SERVER_TLS_CA_FILE).
 for f in "$DEST"/*.crt; do
   [ -f "$f" ] && { cat "$f"; echo; } >> "$DOCK_BUNDLE"
 done


### PR DESCRIPTION
## Summary

- Preserve cluster-injected CA certificates in the fallback CA bundle
- Fixes TLS failures for proxy-intercepted domains (deno.land, jsr.io) on K8s runners

## Root Cause

On K8s runners, /etc/ssl/certs/ is mounted as a read-only ConfigMap containing 427 certs (282 more than the standard Mozilla root store). The Renault squid proxy intercepts TLS for certain domains (deno.land, jsr.io) and re-signs with CAs from this ConfigMap.

The previous fallback path rebuilt the bundle from /usr/share/ca-certificates/mozilla/ only (145 certs), dropping the extra cluster-injected CAs. This caused both curl (error 60) and Deno (UnknownIssuer) to fail for proxy-intercepted domains.

## Fix

When the system bundle is readable, use it as the base for the fallback bundle instead of rebuilding from Mozilla source certs. Imported certs (env vars, drop dir, CI_SERVER_TLS_CA_FILE) are appended on top. Falls back to Mozilla sources only when the system bundle is absent.

## Evidence

Pipeline #29 on Renault kube_m runners confirmed:

| Bundle | deno.land | Cert count |
|--------|-----------|------------|
| Fallback (Mozilla only) | FAIL (curl 60) | 153 |
| System ConfigMap | OK (403) | 427 |
| Combined (system + imported) | OK (403) | 435 |
