### PR TITLE
feat: add jvm-debian and android-debian images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,10 @@ jobs:
             changed=$(git diff --name-only "$base" HEAD)
           fi
 
-          # Dependency tree: core→everything, rust→polyglot
+          # Dependency tree: core→everything, rust→polyglot, jvm→android
           # When a directory changes, both Alpine and Debian variants are tested.
           alpine=(core rust deno node python polyglot lint)
-          debian=(core-debian rust-debian deno-debian node-debian python-debian polyglot-debian)
+          debian=(core-debian rust-debian deno-debian node-debian python-debian polyglot-debian jvm-debian android-debian)
           all_images=("${alpine[@]}" "${debian[@]}")
           images=()
 
@@ -124,11 +124,21 @@ jobs:
             echo "$changed" | grep -qE '^images/rust/'
           }
 
+          needs_jvm() {
+            echo "$changed" | grep -qE '^images/jvm/'
+          }
+
           if needs_all || needs_core; then
             images=("${all_images[@]}")
           else
             if needs_rust; then
               for img in rust polyglot rust-debian polyglot-debian; do
+                add_unique "$img"
+              done
+            fi
+            # jvm changes rebuild jvm-debian + android-debian (dependency)
+            if needs_jvm; then
+              for img in jvm-debian android-debian; do
                 add_unique "$img"
               done
             fi
@@ -145,6 +155,10 @@ jobs:
             if echo "$changed" | grep -qE "^images/polyglot/"; then
               add_unique "polyglot"
               add_unique "polyglot-debian"
+            fi
+            # android directory changes (without jvm)
+            if echo "$changed" | grep -qE "^images/android/"; then
+              add_unique "android-debian"
             fi
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@ alpine:3.21
       ├── :deno          (~120 MB)
       ├── :node          (~115 MB)
       └── :python        (~55 MB)
+
+debian:bookworm-slim (Debian-only images)
+  └── :core-debian
+      └── :jvm-debian    (~290 MB)
+          └── :android-debian (~485 MB)
 ```
 
 **Directory layout:**
@@ -51,7 +56,9 @@ dock/
 │   ├── deno/
 │   ├── node/
 │   ├── python/
-│   └── polyglot/
+│   ├── polyglot/
+│   ├── jvm/
+│   └── android/
 ├── tests/              # bash_unit test suites
 │   └── fixtures/ca/    # test CA certificate
 ├── scripts/            # shared shell utilities

--- a/README.md
+++ b/README.md
@@ -42,15 +42,17 @@ Every image ships in two variants:
 
 ### Available images
 
-| Image       | From          | Size (Alpine) | Contents                                                     |
-| ----------- | ------------- | ------------- | ------------------------------------------------------------ |
-| `:core`     | `alpine:3.21` | ~32 MB        | Shell, Git, curl, jq, yq, gpg, …                             |
-| `:rust`     | `:core`       | ~260 MB       | Rust stable, cargo, clippy, rustfmt, cargo-audit, cargo-deny |
-| `:deno`     | `:core`       | ~120 MB       | Deno                                                         |
-| `:node`     | `:core`       | ~115 MB       | Node.js LTS, npm                                             |
-| `:python`   | `:core`       | ~55 MB        | Python 3, pip, ruff                                          |
-| `:polyglot` | `:rust`       | ~382 MB       | Rust + Deno + Python 3                                       |
-| `:lint`     | `:core`       | ~44 MB        | shellcheck, editorconfig-checker, git-std (linux/amd64 only) |
+| Image       | From          | Size (Alpine) | Contents                                                           |
+| ----------- | ------------- | ------------- | ------------------------------------------------------------------ |
+| `:core`     | `alpine:3.21` | ~32 MB        | Shell, Git, curl, jq, yq, gpg, …                                   |
+| `:rust`     | `:core`       | ~260 MB       | Rust stable, cargo, clippy, rustfmt, cargo-audit, cargo-deny       |
+| `:deno`     | `:core`       | ~120 MB       | Deno                                                               |
+| `:node`     | `:core`       | ~115 MB       | Node.js LTS, npm                                                   |
+| `:python`   | `:core`       | ~55 MB        | Python 3, pip, ruff                                                |
+| `:polyglot` | `:rust`       | ~382 MB       | Rust + Deno + Python 3                                             |
+| `:lint`     | `:core`       | ~44 MB        | shellcheck, editorconfig-checker, git-std (linux/amd64 only)       |
+| `:jvm`      | `:core`       | —             | JDK 17 headless (Debian only)                                      |
+| `:android`  | `:jvm`        | —             | Android SDK cmdline-tools, build-tools, platform SDK (Debian only) |
 
 ## Inheritance Tree
 
@@ -62,6 +64,11 @@ alpine:3.21
       ├── :deno          (~120 MB)
       ├── :node          (~115 MB)
       └── :python        (~55 MB)
+
+debian:bookworm-slim (Debian-only images)
+  └── :core-debian
+      └── :jvm-debian        (~290 MB)
+          └── :android-debian (~485 MB)
 ```
 
 ## Core Package List

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -213,6 +213,28 @@ target "polyglot-debian" {
   contexts = { dock-rust = "target:rust-debian" }
 }
 
+target "jvm-debian" {
+  inherits   = ["_common", "_cache-debian"]
+  context    = "."
+  dockerfile = "images/jvm/Dockerfile.debian"
+  tags = [
+    "${REGISTRY}:jvm-debian-${VERSION}${PLATFORM_SUFFIX}", "${REGISTRY}:jvm-debian${PLATFORM_SUFFIX}",
+    "${REGISTRY_DH}:jvm-debian-${VERSION}${PLATFORM_SUFFIX}", "${REGISTRY_DH}:jvm-debian${PLATFORM_SUFFIX}",
+  ]
+  contexts = { dock-core = "target:core-debian" }
+}
+
+target "android-debian" {
+  inherits   = ["_common", "_cache-debian"]
+  context    = "."
+  dockerfile = "images/android/Dockerfile.debian"
+  tags = [
+    "${REGISTRY}:android-debian-${VERSION}${PLATFORM_SUFFIX}", "${REGISTRY}:android-debian${PLATFORM_SUFFIX}",
+    "${REGISTRY_DH}:android-debian-${VERSION}${PLATFORM_SUFFIX}", "${REGISTRY_DH}:android-debian${PLATFORM_SUFFIX}",
+  ]
+  contexts = { dock-jvm = "target:jvm-debian" }
+}
+
 # ---------------------------------------------------------------------------
 # Groups
 # ---------------------------------------------------------------------------
@@ -234,6 +256,8 @@ group "debian" {
     "node-debian",
     "python-debian",
     "polyglot-debian",
+    "jvm-debian",
+    "android-debian",
   ]
 }
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -30,6 +30,56 @@ FROM ghcr.io/driftsys/dock:rust
 RUN cargo install cargo-nextest --locked
 ```
 
+## Using the JVM image
+
+The `:jvm-debian` image includes JDK 17 headless. Projects using
+Gradle should rely on the Gradle Wrapper (`./gradlew`), which
+downloads the correct Gradle version automatically:
+
+```yaml
+# GitLab CI
+build:
+  image: ghcr.io/driftsys/dock:jvm-debian
+  before_script:
+    - dock-bootstrap
+    - . /etc/dock/ca.env 2>/dev/null || true
+  script:
+    - ./gradlew build
+```
+
+## Using the Android image
+
+The `:android-debian` image includes JDK 17, Android SDK
+command-line tools, build-tools 36.1.0, and platform SDK
+android-36. Install additional platform SDKs at CI time if
+your project targets older API levels:
+
+```yaml
+# GitLab CI
+android-build:
+  image: ghcr.io/driftsys/dock:android-debian
+  before_script:
+    - dock-bootstrap
+    - . /etc/dock/ca.env 2>/dev/null || true
+    - sdkmanager "platforms;android-34" "platforms;android-35"
+  script:
+    - ./gradlew assembleDebug
+```
+
+```yaml
+# GitHub Actions
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ghcr.io/driftsys/dock:android-debian
+    steps:
+      - run: |
+          dock-bootstrap
+          . /etc/dock/ca.env 2>/dev/null || true
+      - uses: actions/checkout@v4
+      - run: ./gradlew assembleDebug
+```
+
 ## Pinning a runtime version
 
 All runtime images accept build arguments for version pinning:

--- a/images/android/Dockerfile.debian
+++ b/images/android/Dockerfile.debian
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+# hadolint ignore=DL3006
+FROM dock-jvm
+
+ARG VERSION=dev
+ARG ANDROID_CMDLINE_TOOLS_VERSION=14742923
+ARG ANDROID_BUILD_TOOLS_VERSION=36.1.0
+ARG ANDROID_PLATFORM_VERSION=36
+
+ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Download and install Android command-line tools
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    unzip \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p "${ANDROID_HOME}/cmdline-tools" \
+ && curl -fsSL "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_CMDLINE_TOOLS_VERSION}_latest.zip" \
+    -o /tmp/cmdline-tools.zip \
+ && unzip -q /tmp/cmdline-tools.zip -d /tmp/cmdline-tools \
+ && mv /tmp/cmdline-tools/cmdline-tools "${ANDROID_HOME}/cmdline-tools/latest" \
+ && rm -rf /tmp/cmdline-tools.zip /tmp/cmdline-tools
+
+# Accept licenses and install SDK components
+# Note: "yes" exits with SIGPIPE (141) when sdkmanager closes stdin;
+# piping through "true" absorbs the non-zero exit under pipefail.
+RUN yes 2>/dev/null | sdkmanager --licenses > /dev/null 2>&1 || true \
+ && sdkmanager --install \
+    "platform-tools" \
+    "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+    "platforms;android-${ANDROID_PLATFORM_VERSION}"
+
+# Generate manifest
+COPY scripts/manifest.sh /usr/local/bin/manifest.sh
+RUN manifest.sh android "${VERSION}"

--- a/images/jvm/Dockerfile.debian
+++ b/images/jvm/Dockerfile.debian
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+# hadolint ignore=DL3006
+FROM dock-core
+
+ARG VERSION=dev
+
+# Install OpenJDK 17 headless
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-17-jdk-headless \
+ && rm -rf /var/lib/apt/lists/*
+
+# Create arch-neutral symlink so JAVA_HOME works on amd64 and arm64
+RUN ln -s /usr/lib/jvm/java-17-openjdk-"$(dpkg --print-architecture)" \
+    /usr/lib/jvm/java-17-openjdk
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Generate manifest
+COPY scripts/manifest.sh /usr/local/bin/manifest.sh
+RUN manifest.sh jvm "${VERSION}"

--- a/scripts/dock-bootstrap.sh
+++ b/scripts/dock-bootstrap.sh
@@ -107,6 +107,8 @@ fi
 
 # Happy path — update-ca-certificates rebuilds /etc/ssl/certs/.
 if update-ca-certificates 2>/dev/null; then
+  # On JVM images the ca-certificates-java hook automatically rebuilds
+  # the JKS truststore, so no extra keytool work is needed here.
   echo "dock-bootstrap: imported $COUNT certificate source(s) into trust store"
   exit 0
 fi
@@ -148,6 +150,28 @@ export NODE_EXTRA_CA_CERTS=$DOCK_BUNDLE
 export DENO_CERT=$DOCK_BUNDLE
 export PIP_CERT=$DOCK_BUNDLE
 EOF
+
+# -------------------------------------------------------------------------
+# 5. JKS truststore fallback (JVM images on read-only K8s runners)
+# -------------------------------------------------------------------------
+if command -v keytool >/dev/null 2>&1 && [ -n "${JAVA_HOME:-}" ]; then
+  JKS_SRC="${JAVA_HOME}/lib/security/cacerts"
+  JKS_DST="/etc/dock/cacerts"
+  if [ -f "$JKS_SRC" ]; then
+    cp "$JKS_SRC" "$JKS_DST"
+    for f in "$DEST"/*.crt; do
+      [ -f "$f" ] || continue
+      alias="dock-$(basename "$f" .crt)"
+      keytool -importcert -noprompt -trustcacerts \
+        -keystore "$JKS_DST" -storepass changeit \
+        -alias "$alias" -file "$f" 2>/dev/null || true
+    done
+    # shellcheck disable=SC2016
+    printf 'export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} -Djavax.net.ssl.trustStore=%s"\n' \
+      "$JKS_DST" >> "$DOCK_ENV"
+    echo "dock-bootstrap: updated JKS truststore at $JKS_DST"
+  fi
+fi
 
 echo "dock-bootstrap: imported $COUNT certificate source(s) (read-only trust store, using $DOCK_BUNDLE)"
 echo "dock-bootstrap: source $DOCK_ENV to apply" >&2

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,6 +32,8 @@ declare -A TEST_SCRIPTS=(
     [node-debian]="test_node.sh"
     [python-debian]="test_python.sh"
     [polyglot-debian]="test_polyglot.sh"
+    [jvm-debian]="test_jvm.sh"
+    [android-debian]="test_android.sh"
 )
 
 run_image_tests() {

--- a/tests/test_android.sh
+++ b/tests/test_android.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Android tests — presence + sanity for the :android-debian image.
+# Sources test_jvm.sh so all JVM + core tests also run.
+
+# shellcheck source=tests/test_jvm.sh
+source "$(dirname "$0")/test_jvm.sh"
+
+# ---------------------------------------------------------------------------
+# Presence tests
+# ---------------------------------------------------------------------------
+
+test_sdkmanager_present() { assert "command -v sdkmanager"; }
+
+test_aapt2_present() {
+  # aapt2 lives inside build-tools, not on PATH by default.
+  assert "find \"$ANDROID_HOME\" -name aapt2 -type f | grep -q aapt2"
+}
+
+# ---------------------------------------------------------------------------
+# Sanity tests
+# ---------------------------------------------------------------------------
+
+test_sdkmanager_list() {
+  assert "sdkmanager --list 2>&1 | grep -q 'build-tools'"
+}
+
+test_aapt2_version() {
+  local aapt2
+  aapt2="$(find "$ANDROID_HOME" -name aapt2 -type f | head -1)"
+  assert "\"$aapt2\" version"
+}
+
+test_android_home_set() {
+  assert "[ -n \"$ANDROID_HOME\" ]"
+}
+
+test_android_home_valid_dir() {
+  assert "[ -d \"$ANDROID_HOME\" ]"
+}
+
+test_android_sdk_root_set() {
+  assert "[ -n \"$ANDROID_SDK_ROOT\" ]"
+}

--- a/tests/test_jvm.sh
+++ b/tests/test_jvm.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# JVM tests — presence + sanity for the :jvm-debian image.
+# Sources test_core.sh so all core tests also run.
+
+# shellcheck source=tests/test_core.sh
+source "$(dirname "$0")/test_core.sh"
+
+# ---------------------------------------------------------------------------
+# Presence tests
+# ---------------------------------------------------------------------------
+
+test_java_present()    { assert "command -v java"; }
+test_javac_present()   { assert "command -v javac"; }
+test_keytool_present() { assert "command -v keytool"; }
+
+# ---------------------------------------------------------------------------
+# Sanity tests
+# ---------------------------------------------------------------------------
+
+test_java_version() {
+  assert "java -version 2>&1 | grep -q 'openjdk version \"17\.'"
+}
+
+test_javac_version() {
+  assert "javac -version"
+}
+
+test_java_home_set() {
+  assert "[ -n \"$JAVA_HOME\" ]"
+}
+
+test_java_home_valid_dir() {
+  assert "[ -d \"$JAVA_HOME\" ]"
+}
+
+test_jks_truststore_exists() {
+  assert "[ -f \"${JAVA_HOME}/lib/security/cacerts\" ]"
+}


### PR DESCRIPTION
## Summary

- Add `:jvm-debian` image — JDK 17 headless on core-debian (~290 MB)
- Add `:android-debian` image — Android SDK cmdline-tools, build-tools 36.1.0, platform android-36 on jvm-debian (~485 MB)
- Extend `dock-bootstrap` with JKS truststore fallback for read-only K8s runners

## Details

Two new **Debian-only** Docker images (Android SDK is glibc-only — no Alpine variant):

```
debian:bookworm-slim
  └── :core-debian
      └── :jvm-debian        (~290 MB)
          └── :android-debian (~485 MB)
```

### :jvm-debian
- `openjdk-17-jdk-headless` from Debian repos
- Multi-arch `JAVA_HOME` via symlink (amd64 + arm64)
- `ca-certificates-java` auto-populates JKS truststore

### :android-debian
- Android SDK cmdline-tools (pinned via build arg)
- `platform-tools`, `build-tools;36.1.0`, `platforms;android-36`
- Additional SDKs installable at CI time via `sdkmanager`

### dock-bootstrap JKS fallback
On read-only K8s runners, `dock-bootstrap` now detects `keytool` + `JAVA_HOME` and:
1. Copies the JKS truststore to `/etc/dock/cacerts`
2. Imports PEM certs via `keytool -importcert`
3. Appends `JAVA_TOOL_OPTIONS` to `ca.env`

### Files changed
- `images/jvm/Dockerfile.debian` — new
- `images/android/Dockerfile.debian` — new
- `docker-bake.hcl` — added targets + updated debian group
- `tests/test_jvm.sh` — new (presence + sanity)
- `tests/test_android.sh` — new (presence + sanity)
- `tests/run.sh` — added test matrix entries
- `scripts/dock-bootstrap.sh` — JKS truststore fallback
- `README.md`, `docs/extending.md`, `AGENTS.md` — documentation