### PR TITLE
feat: add dock:pages image + npx shim for dock:deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,9 @@ jobs:
             changed=$(git diff --name-only "$base" HEAD)
           fi
 
-          # Dependency tree: core→everything, rust→polyglot, jvm→android
+          # Dependency tree: core→everything, rust→polyglot, jvm→android, deno→pages
           # When a directory changes, both Alpine and Debian variants are tested.
-          alpine=(core rust deno node python polyglot lint)
+          alpine=(core rust deno node python polyglot lint pages)
           debian=(core-debian rust-debian deno-debian node-debian python-debian polyglot-debian jvm-debian android-debian android-ndk-debian)
           all_images=("${alpine[@]}" "${debian[@]}")
           images=()
@@ -142,12 +142,16 @@ jobs:
                 add_unique "$img"
               done
             fi
-            for img in deno node python lint; do
+            for img in deno node python lint pages; do
               if echo "$changed" | grep -qE "^images/${img}/"; then
                 add_unique "$img"
-                # Add Debian variant (lint has no Debian variant)
-                if [ "$img" != "lint" ]; then
+                # Add Debian variant (lint and pages have no Debian variant)
+                if [ "$img" != "lint" ] && [ "$img" != "pages" ]; then
                   add_unique "${img}-debian"
+                fi
+                # deno changes also rebuild pages (dependency)
+                if [ "$img" = "deno" ]; then
+                  add_unique "pages"
                 fi
               fi
             done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           # Dependency tree: core→everything, rust→polyglot, jvm→android, deno→pages
           # When a directory changes, both Alpine and Debian variants are tested.
           alpine=(core rust deno node python polyglot lint pages)
-          debian=(core-debian rust-debian deno-debian node-debian python-debian polyglot-debian jvm-debian android-debian android-ndk-debian)
+          debian=(core-debian rust-debian deno-debian node-debian python-debian polyglot-debian pages-debian jvm-debian android-debian android-ndk-debian)
           all_images=("${alpine[@]}" "${debian[@]}")
           images=()
 
@@ -145,13 +145,14 @@ jobs:
             for img in deno node python lint pages; do
               if echo "$changed" | grep -qE "^images/${img}/"; then
                 add_unique "$img"
-                # Add Debian variant (lint and pages have no Debian variant)
-                if [ "$img" != "lint" ] && [ "$img" != "pages" ]; then
+                # Add Debian variant (lint has no Debian variant)
+                if [ "$img" != "lint" ]; then
                   add_unique "${img}-debian"
                 fi
                 # deno changes also rebuild pages (dependency)
                 if [ "$img" = "deno" ]; then
                   add_unique "pages"
+                  add_unique "pages-debian"
                 fi
               fi
             done

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ Every image ships in two variants:
 | -------------- | ------------- | ------- | ------- | -------------------------------------------------------------------- |
 | `:core`        | `alpine:3.21` | ~32 MB  | ~80 MB  | Shell, Git, curl, jq, yq, gpg, …                                     |
 | `:rust`        | `:core`       | ~260 MB | ~330 MB | Rust stable, cargo, clippy, rustfmt, cargo-audit, cargo-deny         |
-| `:deno`        | `:core`       | ~120 MB | ~175 MB | Deno                                                                 |
+| `:deno`        | `:core`       | ~120 MB | ~175 MB | Deno, npx shim                                                       |
 | `:node`        | `:core`       | ~115 MB | ~195 MB | Node.js LTS, npm                                                     |
 | `:python`      | `:core`       | ~55 MB  | ~135 MB | Python 3, pip, ruff                                                  |
 | `:polyglot`    | `:rust`       | ~382 MB | ~460 MB | Rust + Deno + Python 3                                               |
 | `:lint`        | `:core`       | ~44 MB  | —       | shellcheck, editorconfig-checker, git-std (linux/amd64 only)         |
+| `:pages`       | `:deno`       | ~190 MB | —       | mdbook, typst, tera-cli, git-std, brotli, mdbook plugins (amd64)     |
 | `:jvm`         | `:core`       | —       | ~290 MB | JDK 17 headless (Debian only)                                        |
 | `:android`     | `:jvm`        | —       | ~485 MB | Android SDK (Debian only · pin: `:android-36-debian`)                |
 | `:android-ndk` | `:android`    | —       | ~2.5 GB | NDK + Rust + cargo-ndk (Debian only · pin: `:android-ndk-27-debian`) |
@@ -65,6 +66,7 @@ alpine:3.21
       ├── :rust          (~260 MB)
       │   └── :polyglot  (~382 MB)
       ├── :deno          (~120 MB)
+      │   └── :pages     (~190 MB)
       ├── :node          (~115 MB)
       └── :python        (~55 MB)
 ```

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -79,6 +79,18 @@ target "lint" {
   platforms = ["linux/amd64"]
 }
 
+target "pages" {
+  inherits   = ["_common", "_cache-alpine"]
+  context    = "."
+  dockerfile = "images/pages/Dockerfile"
+  tags = [
+    "${REGISTRY}:pages-${VERSION}${PLATFORM_SUFFIX}", "${REGISTRY}:pages${PLATFORM_SUFFIX}",
+    "${REGISTRY_DH}:pages-${VERSION}${PLATFORM_SUFFIX}", "${REGISTRY_DH}:pages${PLATFORM_SUFFIX}",
+  ]
+  contexts  = { dock-deno = "target:deno" }
+  platforms = ["linux/amd64"]
+}
+
 # ---------------------------------------------------------------------------
 # Alpine images
 # ---------------------------------------------------------------------------
@@ -277,7 +289,7 @@ target "android-ndk-debian" {
 # ---------------------------------------------------------------------------
 
 group "alpine" {
-  targets = ["core", "rust", "deno", "node", "python", "polyglot", "lint"]
+  targets = ["core", "rust", "deno", "node", "python", "polyglot", "lint", "pages"]
 }
 
 # All multi-arch targets (excludes lint which is amd64-only)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -199,6 +199,18 @@ target "deno-debian" {
   contexts = { dock-core = "target:core-debian" }
 }
 
+target "pages-debian" {
+  inherits   = ["_common", "_cache-debian"]
+  context    = "."
+  dockerfile = "images/pages/Dockerfile.debian"
+  tags = [
+    "${REGISTRY}:pages-debian-${VERSION}${PLATFORM_SUFFIX}", "${REGISTRY}:pages-debian${PLATFORM_SUFFIX}",
+    "${REGISTRY_DH}:pages-debian-${VERSION}${PLATFORM_SUFFIX}", "${REGISTRY_DH}:pages-debian${PLATFORM_SUFFIX}",
+  ]
+  contexts  = { dock-deno = "target:deno-debian" }
+  platforms = ["linux/amd64"]
+}
+
 target "node-debian" {
   inherits   = ["_common", "_cache-debian"]
   context    = "."
@@ -305,6 +317,7 @@ group "debian" {
     "node-debian",
     "python-debian",
     "polyglot-debian",
+    "pages-debian",
     "jvm-debian",
     "android-debian",
     "android-ndk-debian",

--- a/images/deno/Dockerfile
+++ b/images/deno/Dockerfile
@@ -27,6 +27,9 @@ RUN deno --version
 # Point Deno at the system CA bundle for corporate CA support.
 ENV DENO_CERT=/etc/ssl/certs/ca-certificates.crt
 
+# Install npx shim — delegates `npx <pkg> [args...]` to `deno run -A npm:<pkg> [args...]`
+COPY scripts/npx.sh /usr/local/bin/npx
+
 # Generate manifest
 COPY scripts/manifest.sh /usr/local/bin/manifest.sh
 RUN manifest.sh deno "${VERSION}"

--- a/images/deno/Dockerfile.debian
+++ b/images/deno/Dockerfile.debian
@@ -23,6 +23,9 @@ RUN DPKG_ARCH="$(dpkg --print-architecture)" && \
 # Point Deno at the system CA bundle for corporate CA support.
 ENV DENO_CERT=/etc/ssl/certs/ca-certificates.crt
 
+# Install npx shim — delegates `npx <pkg> [args...]` to `deno run -A npm:<pkg> [args...]`
+COPY scripts/npx.sh /usr/local/bin/npx
+
 # Generate manifest
 COPY scripts/manifest.sh /usr/local/bin/manifest.sh
 RUN manifest.sh deno "${VERSION}"

--- a/images/pages/Dockerfile
+++ b/images/pages/Dockerfile
@@ -12,6 +12,9 @@ FROM dock-deno
 
 ARG VERSION=dev
 
+# Use pipefail so curl failures in pipes are caught.
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
 # ---------------------------------------------------------------------------
 # Tool versions (pinned for reproducibility)
 # ---------------------------------------------------------------------------

--- a/images/pages/Dockerfile
+++ b/images/pages/Dockerfile
@@ -1,0 +1,107 @@
+# syntax=docker/dockerfile:1
+#
+# dock:pages — static site generation and documentation tooling.
+#
+# Inherits from dock:deno (Alpine + Deno runtime + npx shim).
+# Adds: mdbook, typst, tera-cli, git-std, mdbook plugins, brotli, fonts.
+#
+# Platform: linux/amd64 only (git-std and mdbook-linkcheck lack arm64 Linux builds).
+
+# hadolint ignore=DL3006
+FROM dock-deno
+
+ARG VERSION=dev
+
+# ---------------------------------------------------------------------------
+# Tool versions (pinned for reproducibility)
+# ---------------------------------------------------------------------------
+ARG MDBOOK_VERSION=0.5.3
+ARG TYPST_VERSION=0.14.2
+ARG TERA_CLI_VERSION=0.5.0
+ARG GIT_STD_VERSION=0.9.0
+ARG MDBOOK_ADMONISH_VERSION=1.20.0
+ARG MDBOOK_KATEX_VERSION=0.10.0-alpha
+ARG MDBOOK_LINKCHECK_VERSION=0.7.7
+
+# ---------------------------------------------------------------------------
+# System packages: compression + fonts
+# ---------------------------------------------------------------------------
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+      brotli \
+      font-noto \
+      xz
+
+# ---------------------------------------------------------------------------
+# mdbook — book/site generator
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+      | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/mdbook && \
+    mdbook --version
+
+# ---------------------------------------------------------------------------
+# typst — PDF/document compiler
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz" \
+      | tar -xJ --strip-components=1 -C /usr/local/bin && \
+    chmod +x /usr/local/bin/typst && \
+    typst --version
+
+# ---------------------------------------------------------------------------
+# tera-cli — Jinja2/Twig-like template engine
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/chevdor/tera-cli/releases/download/v${TERA_CLI_VERSION}/tera-cli-x86_64-unknown-linux-musl.tar.gz" \
+      | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/tera && \
+    tera --version
+
+# ---------------------------------------------------------------------------
+# git-std — git commit conventions + hooks
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/driftsys/git-std/releases/download/v${GIT_STD_VERSION}/git-std-x86_64-unknown-linux-musl.tar.gz" \
+      -o /tmp/git-std.tar.gz && \
+    tar -xzf /tmp/git-std.tar.gz -C /usr/local/bin && \
+    rm /tmp/git-std.tar.gz && \
+    chmod +x /usr/local/bin/git-std && \
+    git-std --version
+
+# ---------------------------------------------------------------------------
+# mdbook-admonish — callout/admonition blocks (note, warning, tip, danger)
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/tommilligan/mdbook-admonish/releases/download/v${MDBOOK_ADMONISH_VERSION}/mdbook-admonish-v${MDBOOK_ADMONISH_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+      | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/mdbook-admonish && \
+    mdbook-admonish --version
+
+# ---------------------------------------------------------------------------
+# mdbook-katex — server-side LaTeX math rendering
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/lzanini/mdbook-katex/releases/download/${MDBOOK_KATEX_VERSION}-binaries/mdbook-katex-v${MDBOOK_KATEX_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+      | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/mdbook-katex && \
+    mdbook-katex --version
+
+# ---------------------------------------------------------------------------
+# mdbook-linkcheck — broken link validation at build time
+# NOTE: Only gnu build available; works via glibc compat layer from dock:deno.
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v${MDBOOK_LINKCHECK_VERSION}/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip" \
+      -o /tmp/mdbook-linkcheck.zip && \
+    unzip -o /tmp/mdbook-linkcheck.zip -d /usr/local/bin && \
+    rm /tmp/mdbook-linkcheck.zip && \
+    chmod +x /usr/local/bin/mdbook-linkcheck && \
+    mdbook-linkcheck --version
+
+# ---------------------------------------------------------------------------
+# Generate manifest
+# ---------------------------------------------------------------------------
+COPY scripts/manifest.sh /usr/local/bin/manifest.sh
+RUN manifest.sh pages "${VERSION}"

--- a/images/pages/Dockerfile.debian
+++ b/images/pages/Dockerfile.debian
@@ -57,7 +57,7 @@ RUN curl -sSfL \
 # tera-cli — Jinja2/Twig-like template engine
 # ---------------------------------------------------------------------------
 RUN curl -sSfL \
-      "https://github.com/chevdor/tera-cli/releases/download/v${TERA_CLI_VERSION}/tera-cli-x86_64-unknown-linux-gnu.tar.gz" \
+      "https://github.com/chevdor/tera-cli/releases/download/v${TERA_CLI_VERSION}/tera-cli-x86_64-unknown-linux-musl.tar.gz" \
       | tar -xz -C /usr/local/bin && \
     chmod +x /usr/local/bin/tera && \
     tera --version

--- a/images/pages/Dockerfile.debian
+++ b/images/pages/Dockerfile.debian
@@ -1,0 +1,109 @@
+# syntax=docker/dockerfile:1
+#
+# dock:pages-debian — static site generation and documentation tooling (Debian).
+#
+# Inherits from dock:deno-debian (Debian + Deno runtime + npx shim).
+# Adds: mdbook, typst, tera-cli, git-std, mdbook plugins, brotli, fonts.
+#
+# Platform: linux/amd64 only (git-std and mdbook-linkcheck lack arm64 Linux builds).
+
+# hadolint ignore=DL3006
+FROM dock-deno
+
+ARG VERSION=dev
+
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+# ---------------------------------------------------------------------------
+# Tool versions (pinned for reproducibility)
+# ---------------------------------------------------------------------------
+ARG MDBOOK_VERSION=0.5.3
+ARG TYPST_VERSION=0.14.2
+ARG TERA_CLI_VERSION=0.5.0
+ARG GIT_STD_VERSION=0.9.0
+ARG MDBOOK_ADMONISH_VERSION=1.20.0
+ARG MDBOOK_KATEX_VERSION=0.10.0-alpha
+ARG MDBOOK_LINKCHECK_VERSION=0.7.7
+
+# ---------------------------------------------------------------------------
+# System packages: compression + fonts
+# ---------------------------------------------------------------------------
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      brotli \
+      fonts-noto-core \
+      xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# mdbook — book/site generator
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+      | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/mdbook && \
+    mdbook --version
+
+# ---------------------------------------------------------------------------
+# typst — PDF/document compiler
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz" \
+      | tar -xJ --strip-components=1 -C /usr/local/bin && \
+    chmod +x /usr/local/bin/typst && \
+    typst --version
+
+# ---------------------------------------------------------------------------
+# tera-cli — Jinja2/Twig-like template engine
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/chevdor/tera-cli/releases/download/v${TERA_CLI_VERSION}/tera-cli-x86_64-unknown-linux-gnu.tar.gz" \
+      | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/tera && \
+    tera --version
+
+# ---------------------------------------------------------------------------
+# git-std — git commit conventions + hooks
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/driftsys/git-std/releases/download/v${GIT_STD_VERSION}/git-std-x86_64-unknown-linux-musl.tar.gz" \
+      -o /tmp/git-std.tar.gz && \
+    tar -xzf /tmp/git-std.tar.gz -C /usr/local/bin && \
+    rm /tmp/git-std.tar.gz && \
+    chmod +x /usr/local/bin/git-std && \
+    git-std --version
+
+# ---------------------------------------------------------------------------
+# mdbook-admonish — callout/admonition blocks (note, warning, tip, danger)
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/tommilligan/mdbook-admonish/releases/download/v${MDBOOK_ADMONISH_VERSION}/mdbook-admonish-v${MDBOOK_ADMONISH_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+      | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/mdbook-admonish && \
+    mdbook-admonish --version
+
+# ---------------------------------------------------------------------------
+# mdbook-katex — server-side LaTeX math rendering
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/lzanini/mdbook-katex/releases/download/${MDBOOK_KATEX_VERSION}-binaries/mdbook-katex-v${MDBOOK_KATEX_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+      | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/mdbook-katex && \
+    mdbook-katex --version
+
+# ---------------------------------------------------------------------------
+# mdbook-linkcheck — broken link validation at build time
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v${MDBOOK_LINKCHECK_VERSION}/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip" \
+      -o /tmp/mdbook-linkcheck.zip && \
+    unzip -o /tmp/mdbook-linkcheck.zip -d /usr/local/bin && \
+    rm /tmp/mdbook-linkcheck.zip && \
+    chmod +x /usr/local/bin/mdbook-linkcheck && \
+    mdbook-linkcheck --version
+
+# ---------------------------------------------------------------------------
+# Generate manifest
+# ---------------------------------------------------------------------------
+COPY scripts/manifest.sh /usr/local/bin/manifest.sh
+RUN manifest.sh pages "${VERSION}"

--- a/scripts/npx.sh
+++ b/scripts/npx.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# scripts/npx.sh — thin shim that delegates npx calls to Deno's npm: specifier.
+#
+# Usage:
+#   npx <package> [args...]
+#
+# Equivalent to:
+#   deno run --allow-all npm:<package> [args...]
+#
+# Deno fetches the npm package on first use and caches it in DENO_DIR.
+set -eu
+
+if [ $# -eq 0 ]; then
+  echo "Usage: npx <package> [args...]" >&2
+  exit 1
+fi
+
+pkg="$1"; shift
+exec deno run --allow-all "npm:$pkg" "$@"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -33,6 +33,7 @@ declare -A TEST_SCRIPTS=(
     [node-debian]="test_node.sh"
     [python-debian]="test_python.sh"
     [polyglot-debian]="test_polyglot.sh"
+    [pages-debian]="test_pages.sh"
     [jvm-debian]="test_jvm.sh"
     [android-debian]="test_android.sh"
     [android-ndk-debian]="test_android_ndk.sh"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -26,6 +26,7 @@ declare -A TEST_SCRIPTS=(
     [python]="test_python.sh"
     [polyglot]="test_polyglot.sh"
     [lint]="test_lint.sh"
+    [pages]="test_pages.sh"
     [core-debian]="test_core.sh"
     [rust-debian]="test_rust.sh"
     [deno-debian]="test_deno.sh"

--- a/tests/test_deno.sh
+++ b/tests/test_deno.sh
@@ -43,3 +43,16 @@ test_deno_fixture_workflow() {
 
   rm -rf "$dir"
 }
+
+# ---------------------------------------------------------------------------
+# npx shim tests
+# ---------------------------------------------------------------------------
+
+test_npx_present() { assert "command -v npx"; }
+
+test_npx_no_args_shows_usage() {
+  # npx with no arguments should exit non-zero and print usage
+  if npx 2>/dev/null; then
+    fail "npx with no args should exit non-zero"
+  fi
+}

--- a/tests/test_pages.sh
+++ b/tests/test_pages.sh
@@ -116,7 +116,8 @@ test_brotli_compress() {
 }
 
 test_fonts_installed() {
-  # Noto fonts should be available for typst PDF generation
-  assert "[ -d /usr/share/fonts/noto ]" \
+  # Noto fonts should be available for typst PDF generation.
+  # Alpine: /usr/share/fonts/noto  Debian: /usr/share/fonts/truetype/noto
+  assert "[ -d /usr/share/fonts/noto ] || [ -d /usr/share/fonts/truetype/noto ]" \
     "Noto fonts directory should exist"
 }

--- a/tests/test_pages.sh
+++ b/tests/test_pages.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Pages tests — presence + sanity for the :pages image.
+# Sources test_deno.sh so all deno (and core) tests also run.
+
+# shellcheck source=tests/test_deno.sh
+source "$(dirname "$0")/test_deno.sh"
+
+# ---------------------------------------------------------------------------
+# Presence tests
+# ---------------------------------------------------------------------------
+
+test_mdbook_present()          { assert "command -v mdbook"; }
+test_typst_present()           { assert "command -v typst"; }
+test_tera_present()            { assert "command -v tera"; }
+test_git_std_present()         { assert "command -v git-std"; }
+test_brotli_present()          { assert "command -v brotli"; }
+test_npx_present()             { assert "command -v npx"; }
+test_mdbook_admonish_present() { assert "command -v mdbook-admonish"; }
+test_mdbook_katex_present()    { assert "command -v mdbook-katex"; }
+test_mdbook_linkcheck_present() { assert "command -v mdbook-linkcheck"; }
+
+# ---------------------------------------------------------------------------
+# Version sanity tests
+# ---------------------------------------------------------------------------
+
+test_mdbook_version() {
+  assert "mdbook --version"
+}
+
+test_typst_version() {
+  assert "typst --version"
+}
+
+test_tera_version() {
+  assert "tera --version"
+}
+
+test_git_std_version() {
+  assert "git-std --version"
+}
+
+test_mdbook_admonish_version() {
+  assert "mdbook-admonish --version"
+}
+
+test_mdbook_katex_version() {
+  assert "mdbook-katex --version"
+}
+
+test_mdbook_linkcheck_version() {
+  assert "mdbook-linkcheck --version"
+}
+
+# ---------------------------------------------------------------------------
+# Functional tests
+# ---------------------------------------------------------------------------
+
+test_npx_shim_forwards_args() {
+  # npx must delegate to deno run npm:<pkg> and forward args
+  result="$(npx mustache --version 2>/dev/null || true)"
+  # If mustache is not cached, it will be downloaded on first run.
+  # We just verify npx doesn't error with "Usage:" (i.e., it got a package name).
+  assert "[ $? -eq 0 ] || npx mustache --help >/dev/null 2>&1"
+}
+
+test_mdbook_init_and_build() {
+  local dir
+  dir="$(mktemp -d)"
+
+  mdbook init --title "Test Book" "$dir" --ignore none
+  mdbook build "$dir"
+
+  assert "[ -f ${dir}/book/index.html ]" \
+    "mdbook build should produce index.html"
+
+  rm -rf "$dir"
+}
+
+test_typst_compile() {
+  local dir
+  dir="$(mktemp -d)"
+
+  printf '#set page(paper: "a4")\n= Hello\nWorld\n' > "$dir/test.typ"
+  typst compile "$dir/test.typ" "$dir/test.pdf"
+
+  assert "[ -f ${dir}/test.pdf ]" \
+    "typst compile should produce a PDF"
+
+  rm -rf "$dir"
+}
+
+test_tera_template_render() {
+  local dir
+  dir="$(mktemp -d)"
+
+  printf '{"name": "dock"}' > "$dir/data.json"
+  printf 'Hello {{ name }}!' > "$dir/template.txt"
+
+  result="$(tera --template "$dir/template.txt" "$dir/data.json")"
+  assert_equals "Hello dock!" "$result"
+
+  rm -rf "$dir"
+}
+
+test_brotli_compress() {
+  local dir
+  dir="$(mktemp -d)"
+
+  printf 'compress me' > "$dir/test.txt"
+  brotli "$dir/test.txt"
+
+  assert "[ -f ${dir}/test.txt.br ]" \
+    "brotli should produce a .br file"
+
+  rm -rf "$dir"
+}
+
+test_fonts_installed() {
+  # Noto fonts should be available for typst PDF generation
+  assert "[ -d /usr/share/fonts/noto ]" \
+    "Noto fonts directory should exist"
+}


### PR DESCRIPTION
## Summary

Adds a new `dock:pages` image for static site generation and documentation CI pipelines,
plus an `npx` shim in `dock:deno` that delegates to Deno's npm: specifier.

## dock:deno — npx shim

Installs `/usr/local/bin/npx` that delegates `npx <pkg> [args...]` to
`deno run --allow-all npm:<pkg> [args...]`. Enables npm-ecosystem tooling
without Node.js installed.

## dock:pages — doc-build tooling

New image inheriting from `dock:deno` (linux/amd64 only).

**Included tools:**

| Tool | Version | Purpose |
|------|---------|---------|
| mdbook | 0.5.3 | Book/site generation |
| typst | 0.14.2 | PDF compilation |
| tera-cli | 0.5.0 | Jinja2/Twig templating |
| git-std | 0.9.0 | Commit conventions |
| mdbook-admonish | 1.20.0 | Callout blocks (note/warning/tip) |
| mdbook-katex | 0.10.0-alpha | Server-side LaTeX math |
| mdbook-linkcheck | 0.7.7 | Broken link validation |
| brotli | (apk) | Static asset compression |
| font-noto | (apk) | System fonts for typst PDF output |

**Estimated size:** ~190 MB (compressed)

**Platform:** linux/amd64 only (git-std + mdbook-linkcheck lack arm64 Linux builds)

## Inheritance

```
alpine:3.21
  └── :core    (~32 MB)
      └── :deno  (~120 MB)
          └── :pages (~190 MB)  ← NEW
```

## Testing

- `tests/test_pages.sh` — presence, version, and functional tests (mdbook init+build, typst compile, tera render, brotli compress)
- `tests/test_deno.sh` — npx shim presence + no-args validation