### PR TITLE
feat(deno): add npm shim delegating to Deno equivalents

### DIFF
--- a/images/deno/Dockerfile
+++ b/images/deno/Dockerfile
@@ -30,6 +30,9 @@ ENV DENO_CERT=/etc/ssl/certs/ca-certificates.crt
 # Install npx shim — delegates `npx <pkg> [args...]` to `deno run -A npm:<pkg> [args...]`
 COPY scripts/npx.sh /usr/local/bin/npx
 
+# Install npm shim — delegates npm commands to Deno equivalents
+COPY scripts/npm.sh /usr/local/bin/npm
+
 # Generate manifest
 COPY scripts/manifest.sh /usr/local/bin/manifest.sh
 RUN manifest.sh deno "${VERSION}"

--- a/images/deno/Dockerfile.debian
+++ b/images/deno/Dockerfile.debian
@@ -26,6 +26,9 @@ ENV DENO_CERT=/etc/ssl/certs/ca-certificates.crt
 # Install npx shim — delegates `npx <pkg> [args...]` to `deno run -A npm:<pkg> [args...]`
 COPY scripts/npx.sh /usr/local/bin/npx
 
+# Install npm shim — delegates npm commands to Deno equivalents
+COPY scripts/npm.sh /usr/local/bin/npm
+
 # Generate manifest
 COPY scripts/manifest.sh /usr/local/bin/manifest.sh
 RUN manifest.sh deno "${VERSION}"

--- a/scripts/npm.sh
+++ b/scripts/npm.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# scripts/npm.sh — thin shim that delegates npm commands to Deno equivalents.
+#
+# Supported commands:
+#   npm install [args...]     → deno install [args...]
+#   npm ci                    → deno install --frozen
+#   npm run <script> [args..] → deno task <script> [args...]
+#   npm test                  → deno task test
+#   npm exec <pkg> [args...]  → deno run --allow-all npm:<pkg> [args...]
+#   npm init                  → deno init
+#
+# Deno reads package.json natively (Deno 2.x+).
+set -eu
+
+if [ $# -eq 0 ]; then
+  echo "npm: this is a dock shim (delegates to Deno), not full npm." >&2
+  echo "Usage: npm <command> [args...]" >&2
+  echo "" >&2
+  echo "Supported: install, ci, run, test, exec, init" >&2
+  exit 1
+fi
+
+cmd="$1"; shift
+
+case "$cmd" in
+  install|i|add)
+    exec deno install "$@"
+    ;;
+  ci|clean-install)
+    exec deno install --frozen "$@"
+    ;;
+  run|run-script)
+    exec deno task "$@"
+    ;;
+  test|t)
+    exec deno task test "$@"
+    ;;
+  exec)
+    if [ $# -eq 0 ]; then
+      echo "Usage: npm exec <package> [args...]" >&2
+      exit 1
+    fi
+    pkg="$1"; shift
+    exec deno run --allow-all "npm:$pkg" "$@"
+    ;;
+  init)
+    exec deno init "$@"
+    ;;
+  *)
+    echo "npm: unsupported command '$cmd' (this is a dock shim, not full npm)." >&2
+    echo "Supported: install, ci, run, test, exec, init" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/npx.sh
+++ b/scripts/npx.sh
@@ -11,6 +11,7 @@
 set -eu
 
 if [ $# -eq 0 ]; then
+  echo "npx: this is a dock shim (deno run npm:<pkg>), not full npx." >&2
   echo "Usage: npx <package> [args...]" >&2
   exit 1
 fi

--- a/tests/test_deno.sh
+++ b/tests/test_deno.sh
@@ -56,3 +56,31 @@ test_npx_no_args_shows_usage() {
     fail "npx with no args should exit non-zero"
   fi
 }
+
+# ---------------------------------------------------------------------------
+# npm shim tests
+# ---------------------------------------------------------------------------
+
+test_npm_present() { assert "command -v npm"; }
+
+test_npm_no_args_shows_usage() {
+  # npm with no arguments should exit non-zero and print usage
+  if npm 2>/dev/null; then
+    fail "npm with no args should exit non-zero"
+  fi
+}
+
+test_npm_unsupported_command_errors() {
+  if npm publish 2>/dev/null; then
+    fail "npm shim should reject unsupported commands"
+  fi
+}
+
+test_npm_init() {
+  local dir
+  dir="$(mktemp -d)"
+  npm init "$dir"
+  assert "[ -f ${dir}/main.ts ] || [ -f ${dir}/deno.json ]" \
+    "npm init should scaffold a project"
+  rm -rf "$dir"
+}


### PR DESCRIPTION
Adds an `npm` shim alongside the existing `npx` shim in dock:deno.

## What

Maps common npm commands to their Deno equivalents:

| `npm` command | Deno equivalent |
|---|---|
| `npm install` / `npm i` / `npm add` | `deno install` |
| `npm ci` | `deno install --frozen` |
| `npm run <script>` | `deno task <script>` |
| `npm test` | `deno task test` |
| `npm exec <pkg>` | `deno run --allow-all npm:<pkg>` |
| `npm init` | `deno init` |
| Anything else | Clear error explaining it's a shim |

## Why

CI scripts and Makefiles often hardcode `npm run` / `npm ci`. This shim
lets them run unmodified on dock:deno without installing Node.js.

Both shims now clearly identify themselves as dock shims in error messages.

## Changes

- `scripts/npm.sh` — new shim (50 lines)
- `images/deno/Dockerfile` — COPY npm.sh
- `images/deno/Dockerfile.debian` — COPY npm.sh
- `tests/test_deno.sh` — presence + sanity tests
- `scripts/npx.sh` — improved error message