### PR TITLE
fix(githooks): align hook scripts with current git-std subcommands

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec git std hooks run commit-msg -- "$@"
+exec git std hook run commit-msg -- "$@"

--- a/.githooks/commit-msg.hooks
+++ b/.githooks/commit-msg.hooks
@@ -1,1 +1,1 @@
-! git std check --file {msg}
+! git std lint --file {msg}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec git std hooks run pre-commit -- "$@"
+exec git std hook run pre-commit -- "$@"


### PR DESCRIPTION
## Summary

The `.githooks/` scripts and config were authored against an older `git-std` interface and never updated when upstream renamed two subcommands. As a result, every commit through the hook failed with:

```
error: unrecognized subcommand 'hooks'
  tip: a similar subcommand exists: 'hook'
```

forcing `--no-verify` on every commit and breaking the `git std bump` release flow (the bump step computes the version and updates files, but its internal commit step fails on the hook).

## Root cause

Two renames in upstream `git-std` between Mar 28 (when the hooks were authored) and now:

| Old | New |
| --- | --- |
| `git std hooks run <hook>` | `git std hook run <hook>` (singular) |
| `git std check --file <msg>` | `git std lint --file <msg>` |

The hook scripts and `commit-msg.hooks` config kept the old names.

## Fix

Three one-line edits aligning with the current binary interface:

- `.githooks/commit-msg` — `hooks run` -> `hook run`
- `.githooks/pre-commit` — `hooks run` -> `hook run`
- `.githooks/commit-msg.hooks` — `check --file` -> `lint --file`

## Verification

The commit that introduces this change was **made without `--no-verify`**, proving end-to-end that both hooks now execute cleanly against the installed `git-std 0.11.12`:

```
> just lint
dprint check
  OK just lint
> git std lint --file .git/COMMIT_EDITMSG
valid
  OK git std lint --file .git/COMMIT_EDITMSG
```

## Side notes

- Once merged, `git std bump` should work end-to-end again (no need for the manual commit + tag workaround used for v0.2.5).
- This is the underlying cause of all `--no-verify` usage in PRs #46 and #47.

Generated with [Claude Code](https://claude.com/claude-code)
