### PR TITLE
docs(consistency): align README and mdbook with code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ alpine:3.21
       ├── :rust          (~260 MB)
       │   └── :polyglot  (~382 MB)
       ├── :deno          (~120 MB)
-      │   └── :lint      (~150 MB)
+      │   └── :lint      (~145 MB)
       ├── :node          (~115 MB)
       ├── :python        (~55 MB)
       ├── :pages         (~85 MB)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ debian:bookworm-slim
       ├── :prose-debian         (~215 MB)
       └── :jvm-debian           (~290 MB)
           └── :android-debian   (~485 MB)
+              └── :android-ndk-debian (~2.5 GB)
 ```
 
 ## Core Package List
@@ -104,6 +105,7 @@ All images include these tools from `:core`:
 | gpg                     | gnupg                                      |
 | jq                      | jq                                         |
 | yq                      | yq-go (Alpine) / mikefarah binary (Debian) |
+| coreutils               | coreutils                                  |
 | envsubst                | gettext / gettext-base                     |
 | dotenv                  | shell script (both)                        |
 | ssh                     | openssh-client                             |
@@ -141,8 +143,8 @@ for full documentation.
 ## Tags
 
 Tags follow the format `ghcr.io/driftsys/dock:{image}-{version}` where
-`version` is the semantic release tag (e.g. `v1.2.3`). Floating tags
-(`:core`, `:rust`, …) always point to the latest release.
+`version` is the unprefixed semantic release version (e.g. `0.2.7`).
+Floating tags (`:core`, `:rust`, …) always point to the latest release.
 
 See [docs/versioning.md](docs/versioning.md) for the full strategy.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,8 +56,9 @@ Use the Debian variant when your tools require glibc (e.g. pre-built
 binaries that don't support musl).
 
 Some images are **Debian-only** because their upstream toolchain
-requires glibc: `:jvm-debian` (JDK 17) and `:android-debian`
-(Android SDK). These have no Alpine variant.
+requires glibc: `:jvm-debian` (JDK 17), `:android-debian`
+(Android SDK), and `:android-ndk-debian` (NDK + Rust). These have no
+Alpine variant.
 
 Some images are **amd64-only** because upstream tools lack arm64
 builds: `:lint` and `:pages`. Both ship Alpine and Debian variants.
@@ -68,7 +69,7 @@ Floating tags (`:core`, `:rust`, ...) always point to the latest release.
 For reproducible builds, pin to a version tag:
 
 ```yaml
-container: ghcr.io/driftsys/dock:rust-0.1.0
+container: ghcr.io/driftsys/dock:rust-0.2.7
 ```
 
 ## Inspect the manifest
@@ -83,7 +84,7 @@ docker run --rm ghcr.io/driftsys/dock:rust \
 ```json
 {
   "image": "rust",
-  "version": "0.1.0",
+  "version": "0.2.7",
   "tools": {
     "rustc": "1.83.0",
     "cargo": "1.83.0",

--- a/docs/images/deno.md
+++ b/docs/images/deno.md
@@ -13,14 +13,15 @@ Deno runtime. Inherits all `:core` tools.
 
 ## Installed tools
 
-| Tool | Install method         | Purpose                                      |
-| ---- | ---------------------- | -------------------------------------------- |
-| deno | official static binary | TypeScript/JavaScript runtime                |
-| npx  | shell shim             | Run npm packages via `deno run -A npm:<pkg>` |
-| npm  | shell shim             | Delegates supported npm commands to Deno     |
+| Tool | Install method        | Purpose                                      |
+| ---- | --------------------- | -------------------------------------------- |
+| deno | official Docker image | TypeScript/JavaScript runtime                |
+| npx  | shell shim            | Run npm packages via `deno run -A npm:<pkg>` |
+| npm  | shell shim            | Delegates supported npm commands to Deno     |
 
-Deno is installed from the official GitHub release binary. The version
-is controlled by the `DENO_VERSION` build argument.
+Deno is copied from the official `denoland/deno` Docker image via a
+multi-stage build (along with its bundled runtime libraries). The
+version is controlled by the `DENO_VERSION` build argument.
 
 The `npx` and `npm` shims allow using npm ecosystem tools without
 installing Node.js. They delegate to Deno under the hood:

--- a/docs/images/lint.md
+++ b/docs/images/lint.md
@@ -13,12 +13,12 @@ Linting toolbox. Inherits all `:deno` tools (including npx/npm shims).
 
 ## Installed tools
 
-| Tool                 | Install method           | Purpose                                 |
-| -------------------- | ------------------------ | --------------------------------------- |
-| dprint               | binary (GitHub releases) | Fast code formatter (md/json/toml/yaml) |
-| shellcheck           | apk                      | Shell script linter                     |
-| editorconfig-checker | apk                      | EditorConfig rule checker               |
-| git-std              | binary (GitHub releases) | Conventional commits + git hooks        |
+| Tool                 | Install method                 | Purpose                                 |
+| -------------------- | ------------------------------ | --------------------------------------- |
+| dprint               | binary (GitHub releases)       | Fast code formatter (md/json/toml/yaml) |
+| shellcheck           | apk                            | Shell script linter                     |
+| editorconfig-checker | apk (Alpine) / binary (Debian) | EditorConfig rule checker               |
+| git-std              | binary (GitHub releases)       | Conventional commits + git hooks        |
 
 Because `:lint` inherits from `:deno`, you also have access to
 `npx` and `npm` shims. This means any npm-based linter is available

--- a/docs/images/polyglot.md
+++ b/docs/images/polyglot.md
@@ -16,12 +16,12 @@ All-in-one image for mixed-language pipelines. Inherits all `:rust` tools
 
 Includes everything from `:rust` plus:
 
-| Tool    | Install method         | Purpose                       |
-| ------- | ---------------------- | ----------------------------- |
-| deno    | official static binary | TypeScript/JavaScript runtime |
-| python3 | apk                    | Python 3 interpreter          |
-| pip     | apk (py3-pip)          | Package installer             |
-| ruff    | pip                    | Linter and formatter          |
+| Tool    | Install method        | Purpose                       |
+| ------- | --------------------- | ----------------------------- |
+| deno    | official Docker image | TypeScript/JavaScript runtime |
+| python3 | apk                   | Python 3 interpreter          |
+| pip     | apk (py3-pip)         | Package installer             |
+| ruff    | pip                   | Linter and formatter          |
 
 ## Use case: Deno FFI with Rust
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -24,18 +24,20 @@ covers their pipeline.
 
 ## Image catalog
 
-| Image       | From    | Alpine  | Debian  | Contents                                  |
-| ----------- | ------- | ------- | ------- | ----------------------------------------- |
-| `:core`     | alpine  | ~32 MB  | ~80 MB  | Shell, Git, curl, jq, yq, gpg             |
-| `:rust`     | `:core` | ~260 MB | ~330 MB | Rust stable, cargo, clippy, rustfmt       |
-| `:deno`     | `:core` | ~120 MB | ~175 MB | Deno runtime, npx/npm shims               |
-| `:node`     | `:core` | ~115 MB | ~195 MB | Node.js LTS, npm                          |
-| `:python`   | `:core` | ~55 MB  | ~135 MB | Python 3, pip, ruff                       |
-| `:polyglot` | `:rust` | ~382 MB | ~460 MB | Rust + Deno + Python 3                    |
-| `:lint`     | `:deno` | ~145 MB | ~200 MB | dprint, shellcheck, editorconfig, git-std |
-| `:pages`    | `:core` | ~85 MB  | ~140 MB | mdbook, typst, tera-cli, brotli           |
-| `:jvm`      | `:core` | —       | ~290 MB | JDK 17 headless (Debian only)             |
-| `:android`  | `:jvm`  | —       | ~485 MB | Android SDK, build-tools (Debian only)    |
+| Image          | From       | Alpine  | Debian  | Contents                                  |
+| -------------- | ---------- | ------- | ------- | ----------------------------------------- |
+| `:core`        | alpine     | ~32 MB  | ~80 MB  | Shell, Git, curl, jq, yq, gpg             |
+| `:rust`        | `:core`    | ~260 MB | ~330 MB | Rust stable, cargo, clippy, rustfmt       |
+| `:deno`        | `:core`    | ~120 MB | ~175 MB | Deno runtime, npx/npm shims               |
+| `:node`        | `:core`    | ~115 MB | ~195 MB | Node.js LTS, npm                          |
+| `:python`      | `:core`    | ~55 MB  | ~135 MB | Python 3, pip, ruff                       |
+| `:polyglot`    | `:rust`    | ~382 MB | ~460 MB | Rust + Deno + Python 3                    |
+| `:lint`        | `:deno`    | ~145 MB | ~200 MB | dprint, shellcheck, editorconfig, git-std |
+| `:pages`       | `:core`    | ~85 MB  | ~140 MB | mdbook, typst, tera-cli, brotli           |
+| `:prose`       | `:core`    | ~50 MB  | ~215 MB | typos, harper-cli (vale on Debian only)   |
+| `:jvm`         | `:core`    | —       | ~290 MB | JDK 17 headless (Debian only)             |
+| `:android`     | `:jvm`     | —       | ~485 MB | Android SDK, build-tools (Debian only)    |
+| `:android-ndk` | `:android` | —       | ~2.5 GB | NDK + Rust + cargo-ndk (Debian only)      |
 
 ## Inheritance tree
 


### PR DESCRIPTION
## Summary

Documentation drift found while reviewing the last two weeks of changes
(v0.2.0 → v0.2.7). The `pages`/`prose` images were re-parented onto
`:core` (#51) and `:prose` + `:android-ndk` were added, but the
aggregate inheritance trees and catalog tables were not fully updated.
No version-pin mismatches were found — the drift was confined to the
summary trees/catalogs and a few stale install-method descriptions.

## Changes

- **README.md** — add `:android-ndk-debian` to the Debian inheritance
  tree; add `coreutils` to the core package list; fix the tag example
  to an unprefixed version (`0.2.7`, not `v1.2.3`).
- **AGENTS.md** — reconcile `:lint` size to `~145 MB` (matched the
  catalog tables; was `~150 MB`).
- **docs/introduction.md** — add `:prose` and `:android-ndk` catalog
  rows (table previously listed only 10 of 12 images).
- **docs/getting-started.md** — list `:android-ndk-debian` among the
  Debian-only images; bump stale `0.1.0` pin/manifest examples to
  `0.2.7`.
- **docs/images/deno.md**, **polyglot.md** — Deno is copied from the
  official `denoland/deno` Docker image via multi-stage build, not a
  "GitHub release / static binary".
- **docs/images/lint.md** — `editorconfig-checker` is `apk` on Alpine
  but a GitHub-release binary on Debian.

## Verification

- `just lint` (hadolint + shellcheck + `dprint check`) passes with zero
  warnings; pre-commit hook green.
- Per-image doc pages were already accurate (all version pins match the
  Dockerfiles); only the cross-cutting overview docs needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)