### PR TITLE
fix(tests): eliminate false-green assertions and dotenv silent success

### DIFF
--- a/scripts/dotenv.sh
+++ b/scripts/dotenv.sh
@@ -16,11 +16,17 @@
 
 set -euo pipefail
 
+usage() {
+  echo "usage: dotenv [-f file] run [--] command [args...]" >&2
+  exit 2
+}
+
 env_file=".env"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -f | --file)
+      [[ $# -ge 2 ]] || usage
       env_file="$2"
       shift 2
       ;;
@@ -34,10 +40,17 @@ while [[ $# -gt 0 ]]; do
       break
       ;;
     *)
-      shift
+      # Anything before `run`/`--` that is not a known flag is malformed.
+      # Erroring here prevents `dotenv printenv PATH` (a missing `run`)
+      # from silently discarding the command and exiting 0.
+      usage
       ;;
   esac
 done
+
+# A command is mandatory; never exec an empty argv (which would exit 0
+# having run nothing — a silent false success).
+[[ $# -gt 0 ]] || usage
 
 if [[ -f "$env_file" ]]; then
   set -a

--- a/tests/test_lint.sh
+++ b/tests/test_lint.sh
@@ -38,15 +38,33 @@ test_dprint_version() {
 # Functional tests
 # ---------------------------------------------------------------------------
 
-test_dprint_check_valid_json() {
+test_dprint_formats_markdown() {
   local dir
   dir="$(mktemp -d)"
 
-  printf '{"key": "value"}\n' > "$dir/test.json"
-  printf '{\n  "json": {}\n}\n' > "$dir/dprint.json"
+  # A real dprint config must declare a plugin, otherwise dprint errors with
+  # "No formatting plugins found" — the failure the previous `|| true` hid.
+  # Use the markdown plugin (as the repo's own dprint.json does); dprint
+  # downloads the wasm plugin on first use, like the npx/deno tests fetch
+  # their deps.
+  printf '{\n  "markdown": {},\n  "plugins": ["https://plugins.dprint.dev/markdown-0.17.8.wasm"]\n}\n' \
+    > "$dir/dprint.json"
 
-  # dprint check should pass on well-formatted JSON
-  dprint check --config "$dir/dprint.json" "$dir/test.json" || true
+  # Format via --stdin to avoid dprint's working-directory file resolution.
+  # First pass formats messy markdown; the second pass must be a no-op
+  # (dprint's canonical form is idempotent). This exercises the plugin +
+  # formatter end-to-end and fails loudly if dprint is broken, without
+  # hard-coding the version-dependent canonical layout.
+  printf '#  Heading\n\n\nText.\n' \
+    | dprint fmt --stdin doc.md --config "$dir/dprint.json" > "$dir/pass1.md"
+  dprint fmt --stdin doc.md --config "$dir/dprint.json" \
+    < "$dir/pass1.md" > "$dir/pass2.md"
+
+  assert "test -s '$dir/pass1.md'" \
+    "dprint fmt should emit formatted markdown"
+  assert "diff '$dir/pass1.md' '$dir/pass2.md'" \
+    "dprint fmt output should be idempotent (canonical form)"
+
   rm -rf "$dir"
 }
 

--- a/tests/test_prose.sh
+++ b/tests/test_prose.sh
@@ -101,14 +101,16 @@ test_vale_lints_clean_markdown() {
 }
 
 test_typos_detects_known_typo() {
-  local dir output
+  local dir
   dir="$(mktemp -d)"
 
   printf 'This is teh wrong word.\n' > "$dir/typo.md"
 
-  # typos exits non-zero when issues are found.
-  output="$(typos "$dir/typo.md" 2>&1 || true)"
-  assert "echo '$output' | grep -qi 'teh'" \
+  # typos exits non-zero when issues are found. Write to a file and grep it
+  # rather than interpolating the captured output into the assert string,
+  # which would break if the output ever contained a quote.
+  typos "$dir/typo.md" > "$dir/out.txt" 2>&1 || true
+  assert "grep -qi teh '$dir/out.txt'" \
     "typos should flag 'teh' as a typo"
 
   rm -rf "$dir"
@@ -124,15 +126,19 @@ test_typos_passes_clean_text() {
   rm -rf "$dir"
 }
 
-test_harper_cli_runs_on_markdown() {
+test_harper_cli_flags_grammar_error() {
   local dir
   dir="$(mktemp -d)"
 
-  printf '# Heading\n\nThis is a test sentence.\n' > "$dir/clean.md"
-  # harper-cli `lint` exits 0 on success. We only check that it runs.
-  harper-cli lint "$dir/clean.md" >/dev/null 2>&1 || true
-  assert "harper-cli --help" \
-    "harper-cli should expose its help"
+  # "a apple" is an obvious article error harper should catch. Capture both
+  # streams and assert the lint emits a finding, rather than the previous
+  # test which swallowed the result and only re-checked `--help` (a no-op
+  # already covered by the presence/version tests). We assert on output
+  # presence rather than the exit code, which varies across harper versions.
+  printf '# Heading\n\nThis is a apple.\n' > "$dir/bad.md"
+  harper-cli lint "$dir/bad.md" > "$dir/out.txt" 2>&1 || true
+  assert "[ -s '$dir/out.txt' ]" \
+    "harper-cli lint should emit a finding for 'a apple'"
 
   rm -rf "$dir"
 }


### PR DESCRIPTION
## Summary

Found while reviewing the last two weeks of changes: several test
assertions passed unconditionally (false greens), and the `dotenv` shim
could exit 0 having run nothing. None are functional image bugs, but they
let regressions slip through CI.

## Changes

- **scripts/dotenv.sh** — `dotenv printenv PATH` (missing `run`) used to
  fall through the catch-all branch, discard every token, and `exec` an
  empty argv → exit 0 with the command never executed. Now an unrecognised
  pre-command token, an empty command, or `-f` with no value prints usage
  and exits 2. (`-f` with no value previously crashed under `set -u`.)
- **tests/test_lint.sh** — `dprint check … || true` swallowed the outcome
  and asserted nothing; its config also declared no plugin, so dprint could
  never actually format. Replaced with a real `--stdin` round-trip against
  the markdown plugin (the one the repo's own `dprint.json` uses): format
  messy markdown, then assert the output is non-empty and idempotent (a
  second pass is a no-op). Fails loudly if dprint is broken; no dependence
  on a working directory or the version-specific canonical layout.
- **tests/test_prose.sh** — `test_harper_cli_runs_on_markdown` swallowed
  the lint and only re-checked `--help` (already covered by the
  presence/version tests). Now feeds a known article error (`a apple`) and
  asserts harper emits a finding, keyed on output presence rather than
  harper's version-dependent exit code.
- **tests/test_prose.sh** — `test_typos_detects_known_typo` interpolated
  captured output into the `assert` string (breaks on a stray quote); now
  greps an output file.

## Verification

- `shellcheck` (repo invocation over all `scripts`/`tests`) — clean.
- `dprint check` — clean. Pre-commit `just lint` green.
- CI image matrix: `lint`, `lint-debian`, `prose`, `prose-debian` all green
  (these exercise the dprint / harper / typos assertions in the real
  images).
- Exercised dotenv.sh locally: valid `run -- cmd` → output + exit 0;
  missing `run`, empty command, and bare `-f` → usage + exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
