### PR TITLE
feat(images)!: extract git-std into a dedicated :std image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
           # Dependency tree: core→everything, rust→polyglot, jvm→android, deno→lint
           # When a directory changes, both Alpine and Debian variants are tested.
           # python, prose, and polyglot are Debian-only (no Alpine build).
-          alpine=(core rust deno node lint pages)
-          debian=(core-debian rust-debian deno-debian node-debian python-debian polyglot-debian lint-debian pages-debian prose-debian jvm-debian android-debian android-ndk-debian)
+          alpine=(core rust deno node lint std pages)
+          debian=(core-debian rust-debian deno-debian node-debian python-debian polyglot-debian lint-debian std-debian pages-debian prose-debian jvm-debian android-debian android-ndk-debian)
           all_images=("${alpine[@]}" "${debian[@]}")
           images=()
 
@@ -143,7 +143,7 @@ jobs:
                 add_unique "$img"
               done
             fi
-            for img in deno node lint pages; do
+            for img in deno node lint std pages; do
               if echo "$changed" | grep -qE "^images/${img}/"; then
                 add_unique "$img"
                 add_unique "${img}-debian"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,9 +133,10 @@ jobs:
             android-ndk-${{ steps.ndk.outputs.ndk }} android-ndk-${{ steps.ndk.outputs.ndk }}-debian
           )
 
-          # lint and pages (bare, -alpine, and -debian) are amd64-only; retag
-          # the amd64 build directly instead of merging a multi-arch manifest.
-          for img in lint lint-alpine lint-debian pages pages-alpine pages-debian; do
+          # lint, std, and pages (bare, -alpine, and -debian) are amd64-only;
+          # retag the amd64 build directly instead of merging a multi-arch
+          # manifest.
+          for img in lint lint-alpine lint-debian std std-alpine std-debian pages pages-alpine pages-debian; do
             for registry in "$REGISTRY" "$REGISTRY_DH"; do
               docker buildx imagetools create \
                 -t "${registry}:${img}-${VERSION}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ alpine:3.21                  # Alpine variants (-alpine)
       ├── :deno
       │   └── :lint
       ├── :node
+      ├── :std
       └── :pages
 
 debian:bookworm-slim         # Debian variants (-debian) — every image
@@ -49,6 +50,7 @@ debian:bookworm-slim         # Debian variants (-debian) — every image
       ├── :deno-debian
       │   └── :lint-debian
       ├── :node-debian
+      ├── :std-debian
       ├── :python-debian
       ├── :pages-debian
       ├── :prose-debian
@@ -66,6 +68,7 @@ dock/
 │   ├── rust/
 │   ├── deno/
 │   ├── lint/
+│   ├── std/
 │   ├── pages/
 │   ├── prose/
 │   ├── node/

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Sizes are compressed (download) size, amd64.
 | `:rust`        | `:core`       | **debian** | ~557 MB | ~551 MB | Rust stable, cargo, clippy, rustfmt, cargo-audit, cargo-deny |
 | `:deno`        | `:core`       | **alpine** | ~78 MB  | ~121 MB | Deno, npx shim, npm shim                                     |
 | `:node`        | `:core`       | **alpine** | ~54 MB  | ~135 MB | Node.js LTS, npm                                             |
-| `:lint`        | `:deno`       | **alpine** | ~94 MB  | ~138 MB | dprint, shellcheck, editorconfig-checker, git-std (amd64)    |
+| `:lint`        | `:deno`       | **alpine** | ~92 MB  | ~135 MB | dprint, shellcheck, editorconfig-checker (amd64)             |
+| `:std`         | `:core`       | **alpine** | ~32 MB  | ~77 MB  | git-std — conventional commits, changelog, hooks (amd64)     |
 | `:pages`       | `:core`       | **alpine** | ~77 MB  | ~134 MB | mdbook, typst, tera-cli, lychee, brotli (amd64)              |
 | `:python`      | `:core`       | **debian** | —       | ~104 MB | Python 3, pip, ruff                                          |
 | `:prose`       | `:core`       | **debian** | —       | ~106 MB | vale, typos, harper-cli, Vale style packs                    |
@@ -77,8 +78,9 @@ alpine:3.21
   └── :core          (~30 MB)
       ├── :rust      (~557 MB)
       ├── :deno      (~78 MB)
-      │   └── :lint  (~94 MB)
+      │   └── :lint  (~92 MB)
       ├── :node      (~54 MB)
+      ├── :std       (~32 MB)
       └── :pages     (~77 MB)
 ```
 
@@ -90,8 +92,9 @@ debian:bookworm-slim
       ├── :rust-debian          (~551 MB)
       │   └── :polyglot-debian  (~625 MB)
       ├── :deno-debian          (~121 MB)
-      │   └── :lint-debian      (~138 MB)
+      │   └── :lint-debian      (~135 MB)
       ├── :node-debian          (~135 MB)
+      ├── :std-debian           (~77 MB)
       ├── :python-debian        (~104 MB)
       ├── :pages-debian         (~134 MB)
       ├── :prose-debian         (~106 MB)
@@ -106,8 +109,8 @@ Default to **`:image`** — it points to the variant we recommend. Override only
 when you have a specific reason:
 
 - **Alpine (`-alpine`)** — smallest footprint; the default for `core`, `deno`,
-  `node`, `lint`, and `pages`. Pick `:rust-alpine` when you want static musl
-  binaries.
+  `node`, `lint`, `std`, and `pages`. Pick `:rust-alpine` when you want static
+  musl binaries.
 - **Debian (`-debian`)** — broadest compatibility; the default for `rust` (the
   gnu tier-1 target), and the only option for `python`, `prose`, `polyglot`,
   and the JVM/Android images.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -137,6 +137,15 @@ target "lint" {
   platforms  = ["linux/amd64"]
 }
 
+target "std" {
+  inherits   = ["_common", "_cache-alpine"]
+  context    = "."
+  dockerfile = "images/std/Dockerfile"
+  tags       = img_tags("std", "alpine", true)
+  contexts   = { dock-core = "target:core" }
+  platforms  = ["linux/amd64"]
+}
+
 target "pages" {
   inherits   = ["_common", "_cache-alpine"]
   context    = "."
@@ -208,6 +217,15 @@ target "lint-debian" {
   platforms  = ["linux/amd64"]
 }
 
+target "std-debian" {
+  inherits   = ["_common", "_cache-debian"]
+  context    = "."
+  dockerfile = "images/std/Dockerfile.debian"
+  tags       = img_tags("std", "debian", false)
+  contexts   = { dock-core = "target:core-debian" }
+  platforms  = ["linux/amd64"]
+}
+
 target "pages-debian" {
   inherits   = ["_common", "_cache-debian"]
   context    = "."
@@ -266,10 +284,10 @@ target "android-ndk-debian" {
 # ---------------------------------------------------------------------------
 
 group "alpine" {
-  targets = ["core", "rust", "deno", "node", "lint", "pages"]
+  targets = ["core", "rust", "deno", "node", "lint", "std", "pages"]
 }
 
-# Multi-arch targets (excludes lint and pages which are amd64-only)
+# Multi-arch targets (excludes lint, std, and pages which are amd64-only)
 group "multiarch" {
   targets = ["core", "rust", "deno", "node"]
 }
@@ -290,5 +308,5 @@ group "debian" {
 }
 
 group "default" {
-  targets = ["alpine", "debian", "pages-debian", "lint-debian"]
+  targets = ["alpine", "debian", "pages-debian", "lint-debian", "std-debian"]
 }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
 - [python](images/python.md)
 - [polyglot](images/polyglot.md)
 - [lint](images/lint.md)
+- [std](images/std.md)
 - [pages](images/pages.md)
 - [prose](images/prose.md)
 - [jvm](images/jvm.md)

--- a/docs/images/lint.md
+++ b/docs/images/lint.md
@@ -18,7 +18,9 @@ Linting toolbox. Inherits all `:deno` tools (including npx/npm shims).
 | dprint               | binary (GitHub releases)       | Fast code formatter (md/json/toml/yaml) |
 | shellcheck           | apk                            | Shell script linter                     |
 | editorconfig-checker | apk (Alpine) / binary (Debian) | EditorConfig rule checker               |
-| git-std              | binary (GitHub releases)       | Conventional commits + git hooks        |
+
+> `git-std` (conventional commits, changelog, versioning, git hooks) now
+> ships in its own [`:std`](std.md) image, not `:lint`.
 
 Because `:lint` inherits from `:deno`, you also have access to
 `npx` and `npm` shims. This means any npm-based linter is available
@@ -31,8 +33,8 @@ npx prettier --check "**/*.yaml"
 
 ## Platform note
 
-`git-std` releases only provide a Linux x86_64 binary. This image is
-built for `linux/amd64` only.
+`dprint` (both variants) and `editorconfig-checker` (Debian) are installed
+as x86_64 binaries. This image is built for `linux/amd64` only.
 
 ## Usage in CI
 
@@ -47,19 +49,17 @@ jobs:
       - run: npx markdownlint-cli2 "**/*.md"
       - run: shellcheck scripts/*.sh
       - run: editorconfig-checker
-      - run: git-std check
 ```
 
 ## Build arguments
 
-| Argument          | Default   | Description                |
-| ----------------- | --------- | -------------------------- |
-| `DPRINT_VERSION`  | `0.54.0`  | dprint release to install  |
-| `GIT_STD_VERSION` | `0.11.12` | git-std release to install |
+| Argument         | Default  | Description               |
+| ---------------- | -------- | ------------------------- |
+| `DPRINT_VERSION` | `0.54.0` | dprint release to install |
 
 ## Approximate size
 
 | Variant | Size    |
 | ------- | ------- |
-| Alpine  | ~145 MB |
-| Debian  | ~200 MB |
+| Alpine  | ~92 MB  |
+| Debian  | ~135 MB |

--- a/docs/images/std.md
+++ b/docs/images/std.md
@@ -1,0 +1,52 @@
+# :std
+
+`git-std` toolbox. Inherits all `:core` tools (shell, git, curl, jq, …).
+
+## Base
+
+| Variant          | Base                                                |
+| ---------------- | --------------------------------------------------- |
+| Alpine (default) | `ghcr.io/driftsys/dock:core` (build context)        |
+| Debian           | `ghcr.io/driftsys/dock:core-debian` (build context) |
+
+## Installed tools
+
+| Tool    | Install method           | Purpose                                            |
+| ------- | ------------------------ | -------------------------------------------------- |
+| git-std | binary (GitHub releases) | Conventional commits, changelog, versioning, hooks |
+
+`git-std` is a single static binary that replaces commitizen, commitlint,
+standard-version, husky, and lefthook. Invoke it directly (`git-std …`) or
+as a git subcommand (`git std …`).
+
+## Platform note
+
+`git-std` releases only provide a Linux x86_64 binary. This image is
+built for `linux/amd64` only.
+
+## Usage in CI
+
+```yaml
+jobs:
+  commits:
+    runs-on: ubuntu-latest
+    container: ghcr.io/driftsys/dock:std
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git std lint --range origin/main..HEAD
+```
+
+## Build arguments
+
+| Argument          | Default   | Description                |
+| ----------------- | --------- | -------------------------- |
+| `GIT_STD_VERSION` | `0.11.12` | git-std release to install |
+
+## Approximate size
+
+| Variant | Size   |
+| ------- | ------ |
+| Alpine  | ~32 MB |
+| Debian  | ~77 MB |

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -27,20 +27,21 @@ covers their pipeline.
 Sizes are compressed (download) size, amd64. The **`:image` →** column is the
 variant the bare `:image` tag resolves to.
 
-| Image          | From       | `:image` → | Alpine  | Debian  | Contents                                  |
-| -------------- | ---------- | ---------- | ------- | ------- | ----------------------------------------- |
-| `:core`        | alpine     | alpine     | ~30 MB  | ~76 MB  | Shell, Git, curl, jq, yq, gpg             |
-| `:rust`        | `:core`    | debian     | ~557 MB | ~551 MB | Rust stable, cargo, clippy, rustfmt       |
-| `:deno`        | `:core`    | alpine     | ~78 MB  | ~121 MB | Deno runtime, npx/npm shims               |
-| `:node`        | `:core`    | alpine     | ~54 MB  | ~135 MB | Node.js LTS, npm                          |
-| `:lint`        | `:deno`    | alpine     | ~94 MB  | ~138 MB | dprint, shellcheck, editorconfig, git-std |
-| `:pages`       | `:core`    | alpine     | ~77 MB  | ~134 MB | mdbook, typst, tera-cli, lychee           |
-| `:python`      | `:core`    | debian     | —       | ~104 MB | Python 3, pip, ruff                       |
-| `:prose`       | `:core`    | debian     | —       | ~106 MB | vale, typos, harper-cli                   |
-| `:polyglot`    | `:rust`    | debian     | —       | ~625 MB | Rust + Deno + Python 3                    |
-| `:jvm`         | `:core`    | debian     | —       | ~218 MB | JDK 17 headless                           |
-| `:android`     | `:jvm`     | debian     | —       | ~489 MB | Android SDK, build-tools                  |
-| `:android-ndk` | `:android` | debian     | —       | ~1.7 GB | NDK + Rust + cargo-ndk                    |
+| Image          | From       | `:image` → | Alpine  | Debian  | Contents                            |
+| -------------- | ---------- | ---------- | ------- | ------- | ----------------------------------- |
+| `:core`        | alpine     | alpine     | ~30 MB  | ~76 MB  | Shell, Git, curl, jq, yq, gpg       |
+| `:rust`        | `:core`    | debian     | ~557 MB | ~551 MB | Rust stable, cargo, clippy, rustfmt |
+| `:deno`        | `:core`    | alpine     | ~78 MB  | ~121 MB | Deno runtime, npx/npm shims         |
+| `:node`        | `:core`    | alpine     | ~54 MB  | ~135 MB | Node.js LTS, npm                    |
+| `:lint`        | `:deno`    | alpine     | ~92 MB  | ~135 MB | dprint, shellcheck, editorconfig    |
+| `:std`         | `:core`    | alpine     | ~32 MB  | ~77 MB  | git-std (commits, changelog, hooks) |
+| `:pages`       | `:core`    | alpine     | ~77 MB  | ~134 MB | mdbook, typst, tera-cli, lychee     |
+| `:python`      | `:core`    | debian     | —       | ~104 MB | Python 3, pip, ruff                 |
+| `:prose`       | `:core`    | debian     | —       | ~106 MB | vale, typos, harper-cli             |
+| `:polyglot`    | `:rust`    | debian     | —       | ~625 MB | Rust + Deno + Python 3              |
+| `:jvm`         | `:core`    | debian     | —       | ~218 MB | JDK 17 headless                     |
+| `:android`     | `:jvm`     | debian     | —       | ~489 MB | Android SDK, build-tools            |
+| `:android-ndk` | `:android` | debian     | —       | ~1.7 GB | NDK + Rust + cargo-ndk              |
 
 ## Inheritance tree
 
@@ -51,8 +52,9 @@ alpine:3.21
   └── :core          (~30 MB)
       ├── :rust      (~557 MB)
       ├── :deno      (~78 MB)
-      │   └── :lint  (~94 MB, amd64 only)
+      │   └── :lint  (~92 MB, amd64 only)
       ├── :node      (~54 MB)
+      ├── :std       (~32 MB, amd64 only)
       └── :pages     (~77 MB, amd64 only)
 ```
 
@@ -64,8 +66,9 @@ debian:bookworm-slim
       ├── :rust-debian          (~551 MB)
       │   └── :polyglot-debian  (~625 MB)
       ├── :deno-debian          (~121 MB)
-      │   └── :lint-debian      (~138 MB, amd64 only)
+      │   └── :lint-debian      (~135 MB, amd64 only)
       ├── :node-debian          (~135 MB)
+      ├── :std-debian           (~77 MB, amd64 only)
       ├── :python-debian        (~104 MB)
       ├── :pages-debian         (~134 MB, amd64 only)
       ├── :prose-debian         (~106 MB)

--- a/images/lint/Dockerfile
+++ b/images/lint/Dockerfile
@@ -3,10 +3,10 @@
 # dock:lint — code and documentation linting toolbox (Alpine).
 #
 # Inherits from dock:deno (Alpine + Deno runtime + npx/npm shims).
-# Adds: shellcheck, editorconfig-checker, git-std, dprint.
+# Adds: shellcheck, editorconfig-checker, dprint.
 # npx gives access to markdownlint-cli2, prettier, and any npm linter.
 #
-# Platform: linux/amd64 only (git-std lacks arm64 Linux builds).
+# Platform: linux/amd64 only (dprint is installed as an x86_64 binary).
 
 # hadolint ignore=DL3006
 FROM dock-deno
@@ -18,7 +18,6 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # ---------------------------------------------------------------------------
 # Tool versions (pinned for reproducibility)
 # ---------------------------------------------------------------------------
-ARG GIT_STD_VERSION=0.11.12
 ARG DPRINT_VERSION=0.54.0
 
 # ---------------------------------------------------------------------------
@@ -38,17 +37,6 @@ RUN curl -sSfL \
     rm /tmp/dprint.zip && \
     chmod +x /usr/local/bin/dprint && \
     dprint --version
-
-# ---------------------------------------------------------------------------
-# git-std — git commit conventions + hooks
-# ---------------------------------------------------------------------------
-RUN curl -sSfL \
-      "https://github.com/driftsys/git-std/releases/download/v${GIT_STD_VERSION}/git-std-x86_64-unknown-linux-musl.tar.gz" \
-      -o /tmp/git-std.tar.gz && \
-    tar -xzf /tmp/git-std.tar.gz -C /usr/local/bin && \
-    rm /tmp/git-std.tar.gz && \
-    chmod +x /usr/local/bin/git-std && \
-    git-std --version
 
 # ---------------------------------------------------------------------------
 # Generate manifest

--- a/images/lint/Dockerfile.debian
+++ b/images/lint/Dockerfile.debian
@@ -3,10 +3,11 @@
 # dock:lint-debian — code and documentation linting toolbox (Debian).
 #
 # Inherits from dock:deno-debian (Debian + Deno runtime + npx/npm shims).
-# Adds: shellcheck, editorconfig-checker, git-std, dprint.
+# Adds: shellcheck, editorconfig-checker, dprint.
 # npx gives access to markdownlint-cli2, prettier, and any npm linter.
 #
-# Platform: linux/amd64 only (git-std lacks arm64 Linux builds).
+# Platform: linux/amd64 only (dprint and editorconfig-checker are installed
+# as x86_64 binaries).
 
 # hadolint ignore=DL3006
 FROM dock-deno
@@ -18,7 +19,6 @@ SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 # ---------------------------------------------------------------------------
 # Tool versions (pinned for reproducibility)
 # ---------------------------------------------------------------------------
-ARG GIT_STD_VERSION=0.11.12
 ARG DPRINT_VERSION=0.54.0
 
 # ---------------------------------------------------------------------------
@@ -51,17 +51,6 @@ RUN curl -sSfL \
     rm /tmp/dprint.zip && \
     chmod +x /usr/local/bin/dprint && \
     dprint --version
-
-# ---------------------------------------------------------------------------
-# git-std — git commit conventions + hooks
-# ---------------------------------------------------------------------------
-RUN curl -sSfL \
-      "https://github.com/driftsys/git-std/releases/download/v${GIT_STD_VERSION}/git-std-x86_64-unknown-linux-musl.tar.gz" \
-      -o /tmp/git-std.tar.gz && \
-    tar -xzf /tmp/git-std.tar.gz -C /usr/local/bin && \
-    rm /tmp/git-std.tar.gz && \
-    chmod +x /usr/local/bin/git-std && \
-    git-std --version
 
 # ---------------------------------------------------------------------------
 # Generate manifest

--- a/images/std/Dockerfile
+++ b/images/std/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+#
+# dock:std — git-std toolbox (Alpine).
+#
+# Inherits from dock:core (shell foundation + git).
+# Adds: git-std — conventional commits, changelog, versioning, git hooks.
+#
+# Platform: linux/amd64 only (git-std lacks arm64 Linux builds).
+
+# hadolint ignore=DL3006
+FROM dock-core
+
+ARG VERSION=dev
+
+# ---------------------------------------------------------------------------
+# Tool versions (pinned for reproducibility)
+# ---------------------------------------------------------------------------
+ARG GIT_STD_VERSION=0.11.12
+
+# ---------------------------------------------------------------------------
+# git-std — git commit conventions + hooks
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/driftsys/git-std/releases/download/v${GIT_STD_VERSION}/git-std-x86_64-unknown-linux-musl.tar.gz" \
+      -o /tmp/git-std.tar.gz && \
+    tar -xzf /tmp/git-std.tar.gz -C /usr/local/bin && \
+    rm /tmp/git-std.tar.gz && \
+    chmod +x /usr/local/bin/git-std && \
+    git-std --version
+
+# ---------------------------------------------------------------------------
+# Generate manifest
+# ---------------------------------------------------------------------------
+COPY scripts/manifest.sh /usr/local/bin/manifest.sh
+RUN manifest.sh std "${VERSION}"

--- a/images/std/Dockerfile.debian
+++ b/images/std/Dockerfile.debian
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+#
+# dock:std-debian — git-std toolbox (Debian).
+#
+# Inherits from dock:core-debian (shell foundation + git).
+# Adds: git-std — conventional commits, changelog, versioning, git hooks.
+#
+# Platform: linux/amd64 only (git-std lacks arm64 Linux builds).
+
+# hadolint ignore=DL3006
+FROM dock-core
+
+ARG VERSION=dev
+
+# ---------------------------------------------------------------------------
+# Tool versions (pinned for reproducibility)
+# ---------------------------------------------------------------------------
+ARG GIT_STD_VERSION=0.11.12
+
+# ---------------------------------------------------------------------------
+# git-std — git commit conventions + hooks
+# ---------------------------------------------------------------------------
+RUN curl -sSfL \
+      "https://github.com/driftsys/git-std/releases/download/v${GIT_STD_VERSION}/git-std-x86_64-unknown-linux-musl.tar.gz" \
+      -o /tmp/git-std.tar.gz && \
+    tar -xzf /tmp/git-std.tar.gz -C /usr/local/bin && \
+    rm /tmp/git-std.tar.gz && \
+    chmod +x /usr/local/bin/git-std && \
+    git-std --version
+
+# ---------------------------------------------------------------------------
+# Generate manifest
+# ---------------------------------------------------------------------------
+COPY scripts/manifest.sh /usr/local/bin/manifest.sh
+RUN manifest.sh std "${VERSION}"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -25,6 +25,8 @@ declare -A TEST_SCRIPTS=(
     [node]="test_node.sh"
     [lint]="test_lint.sh"
     [lint-debian]="test_lint.sh"
+    [std]="test_std.sh"
+    [std-debian]="test_std.sh"
     [pages]="test_pages.sh"
     [prose-debian]="test_prose.sh"
     [core-debian]="test_core.sh"
@@ -70,7 +72,7 @@ run_image_tests() {
 if [[ $# -gt 0 ]]; then
     run_image_tests "$1"
 else
-    for image in core rust deno node lint pages \
+    for image in core rust deno node lint std pages \
                  python-debian prose-debian polyglot-debian; do
         run_image_tests "$image"
     done

--- a/tests/test_lint.sh
+++ b/tests/test_lint.sh
@@ -11,7 +11,6 @@ source "$(dirname "$0")/test_deno.sh"
 
 test_shellcheck_present()           { assert "command -v shellcheck"; }
 test_editorconfig_checker_present() { assert "command -v editorconfig-checker"; }
-test_git_std_present()              { assert "command -v git-std"; }
 test_dprint_present()               { assert "command -v dprint"; }
 
 # ---------------------------------------------------------------------------
@@ -24,10 +23,6 @@ test_shellcheck_version() {
 
 test_editorconfig_checker_version() {
   assert "editorconfig-checker --version"
-}
-
-test_git_std_version() {
-  assert "git-std --version"
 }
 
 test_dprint_version() {

--- a/tests/test_std.sh
+++ b/tests/test_std.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Std tests — presence + sanity for the :std image.
+# Sources test_core.sh so all core tests also run.
+
+# shellcheck source=tests/test_core.sh
+source "$(dirname "$0")/test_core.sh"
+
+# ---------------------------------------------------------------------------
+# Presence tests
+# ---------------------------------------------------------------------------
+
+test_git_std_present() { assert "command -v git-std"; }
+
+# ---------------------------------------------------------------------------
+# Version sanity tests
+# ---------------------------------------------------------------------------
+
+test_git_std_version() {
+  assert "git-std --version"
+}
+
+# ---------------------------------------------------------------------------
+# Functional tests
+# ---------------------------------------------------------------------------
+
+test_git_std_subcommand() {
+  # git-std is invoked as `git std` via git subcommand discovery.
+  assert "git std --version"
+}


### PR DESCRIPTION
## What

Extracts `git-std` out of the `:lint` bundle into its own minimal image.

- **New `:std` image** — ships `git-std` only, based on `:core` (it needs
  just `git`, not the Deno/npx stack `:lint` carried). Alpine + Debian
  variants, `amd64`-only (git-std has no arm64 Linux build). Bare `:std`
  resolves to Alpine.
- **Slimmed `:lint`** — now carries `dprint`, `shellcheck`, and
  `editorconfig-checker` (plus the inherited npx linters). No longer ships
  `git-std`.

## Why

`:lint` mixed two concerns — code/doc linters and git-commit tooling — and
pulled the full `:deno` base. Teams that only want `git-std` (conventional
commits, changelog, versioning, hooks) can now use a ~32 MB image instead of
the ~94 MB `:lint`.

## Breaking change

The `:lint` image no longer includes `git-std`. Pipelines that run `git-std`
inside `:lint` should switch to `:std`, or pin `:lint` to a prior release.

## Sizes (measured, compressed/amd64)

| Image          | Alpine | Debian |
| -------------- | ------ | ------ |
| `:std`         | ~32 MB | ~77 MB |

## Testing

- `just lint` — clean (hadolint + shellcheck + dprint).
- `:std-alpine` and `:std-debian` built locally and pass the full bash_unit
  suite (inherited `:core` tests + git-std presence/version/`git std`
  subcommand).
- `docker buildx bake --print` resolves the full target graph including the
  new `std` / `std-debian` targets.

## Files

- New: `images/std/Dockerfile{,.debian}`, `tests/test_std.sh`,
  `docs/images/std.md`.
- Wiring: `docker-bake.hcl`, `.github/workflows/{ci,release}.yml`,
  `tests/run.sh`.
- Docs: `README.md`, `docs/introduction.md`, `docs/SUMMARY.md`,
  `docs/images/lint.md`, `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)